### PR TITLE
OGI_Bullet_LasCannonDual: fix up penetration values

### DIFF
--- a/CombatExtended/Patches/Turret_Tweaks.xml
+++ b/CombatExtended/Patches/Turret_Tweaks.xml
@@ -316,7 +316,9 @@
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<damageDef>OGILasC</damageDef>
 							<damageAmountBase>75</damageAmountBase>
-							<armorPenetrationBase>3.0</armorPenetrationBase>
+							<explosionRadius>0.55</explosionRadius>
+							<armorPenetrationSharp>36</armorPenetrationSharp>
+							<armorPenetrationBlunt>80</armorPenetrationBlunt>
 							<spreadMult>4.8</spreadMult>
 							<pelletCount>2</pelletCount>
 						</projectile>


### PR DESCRIPTION
Values copied from single LasCanon projectile.

Signed-off-by: llt <llt@steam.id>