### PR TITLE
FloatingPawnExtension: suppress warnings about texture field initialization

### DIFF
--- a/1.2/Source/AdeptusMechanicusMain/DefExtentions/FloatingPawnExtension.cs
+++ b/1.2/Source/AdeptusMechanicusMain/DefExtentions/FloatingPawnExtension.cs
@@ -5,6 +5,7 @@ using Verse;
 
 namespace AdeptusMechanicus
 {
+    [StaticConstructorOnStartup]
     // Token: 0x02000020 RID: 32
     public class FloatingPawnExtension : DefModExtension
     {

--- a/1.3/Source/AdeptusMechanicusMain/DefExtentions/FloatingPawnExtension.cs
+++ b/1.3/Source/AdeptusMechanicusMain/DefExtentions/FloatingPawnExtension.cs
@@ -5,6 +5,7 @@ using Verse;
 
 namespace AdeptusMechanicus
 {
+    [StaticConstructorOnStartup]
     // Token: 0x02000020 RID: 32
     public class FloatingPawnExtension : DefModExtension
     {


### PR DESCRIPTION

shadowPropertyBlock field of type MaterialPropertyBlock produced a warning
on startup.

Signed-off-by: llt <llt@steam.id>