### PR TITLE
Update xeno trader to carry xeno crafting supplies

### DIFF
--- a/Defs/TraderKindDefs/OG_AMA_RogueTrader_Xenotech.xml
+++ b/Defs/TraderKindDefs/OG_AMA_RogueTrader_Xenotech.xml
@@ -45,6 +45,38 @@
 					<max>10</max>
 				</countRange>
 			</li>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>OGE_TableMachining</thingDef>		<!-- ELDAR TABLE -->
+				<price>Expensive</price>
+				<countRange>
+					<min>-1</min>
+					<max>1</max>
+				</countRange>
+			</li>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>OGDE_TableMachining</thingDef>		<!-- DARK ELDAR TABLE -->
+				<price>Expensive</price>
+				<countRange>
+					<min>-1</min>
+					<max>1</max>
+				</countRange>
+			</li>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>OGO_TableMachining</thingDef>		<!-- ORK TABLE -->
+				<price>Expensive</price>
+				<countRange>
+					<min>-1</min>
+					<max>1</max>
+				</countRange>
+			</li>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>OGT_TableMachining</thingDef>		<!-- TAU TABLE -->
+				<price>Expensive</price>
+				<countRange>
+					<min>-1</min>
+					<max>1</max>
+				</countRange>
+			</li>
 			<li Class="StockGenerator_Tag">						<!-- THIS DOES CHAOS RANGED WEAPONS -->
 				<tradeTag>OGCRanged</tradeTag>
 				<thingDefCountRange>


### PR DESCRIPTION
Xenotech rogue trader doesn't actually carry crafting supplies currently.  Updated the Trader Defs to give them a chance to carry each.